### PR TITLE
OLH-1130: updated from alphagov to govuk-one-login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@govuk-prototype-kit/common-templates": "1.2.1",
         "govuk-frontend": "4.7.0",
-        "govuk-one-login-service-header": "github:alphagov/di-govuk-one-login-service-header",
+        "govuk-one-login-service-header": "github:govuk-one-login/di-govuk-one-login-service-header",
         "govuk-prototype-kit": "13.10.0"
       }
     },
@@ -1486,7 +1486,7 @@
     },
     "node_modules/govuk-one-login-service-header": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/alphagov/di-govuk-one-login-service-header.git#344876bf81b320c8e684ea504e7ba754bc513aa9",
+      "resolved": "git+ssh://git@github.com/govuk-one-login/di-govuk-one-login-service-header.git#25cb2d00881048031c6b4a0023b6aef429fcffb3",
       "license": "ISC",
       "dependencies": {
         "govuk-frontend": "^4.5.0",
@@ -4573,8 +4573,8 @@
       "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg=="
     },
     "govuk-one-login-service-header": {
-      "version": "git+ssh://git@github.com/alphagov/di-govuk-one-login-service-header.git#344876bf81b320c8e684ea504e7ba754bc513aa9",
-      "from": "govuk-one-login-service-header@alphagov/di-govuk-one-login-service-header",
+      "version": "git+ssh://git@github.com/govuk-one-login/di-govuk-one-login-service-header.git#25cb2d00881048031c6b4a0023b6aef429fcffb3",
+      "from": "govuk-one-login-service-header@github:govuk-one-login/di-govuk-one-login-service-header",
       "requires": {
         "govuk-frontend": "^4.5.0",
         "nunjucks": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@govuk-prototype-kit/common-templates": "1.2.1",
     "govuk-frontend": "4.7.0",
-    "govuk-one-login-service-header": "github:alphagov/di-govuk-one-login-service-header",
+    "govuk-one-login-service-header": "github:govuk-one-login/di-govuk-one-login-service-header",
     "govuk-prototype-kit": "13.10.0"
   }
 }


### PR DESCRIPTION
As part of transferring ownership of repo from alphagov to govuk-one-login (a trust initiative) this PR has updated any old package references to point to new location.