### PR TITLE
OLH-2647 Standardise commit messages through pre-commit

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,32 @@
+[general]
+ignore=B6
+verbosity = 3
+ignore-merge-commits=true
+ignore-revert-commits=true
+ignore-fixup-commits=false
+ignore-fixup-amend-commits=false
+ignore-squash-commits=false
+debug=false
+regex-style-search=True
+staged=true
+
+[title-max-length]
+line-length=72
+
+[title-min-length]
+min-length=10
+
+[title-must-not-contain-word]
+words=wip
+
+[title-match-regex]
+regex=^(BAU|OLH-[0-9]{1,4})[: ]+\w
+
+[author-valid-email]
+regex=[\w\.\+_-]+@(digital.cabinet-office.gov.uk|users.noreply.github.com)
+
+[ignore-body-lines]
+regex=^Co-authored-by
+
+[ignore-by-author-name]
+regex=(.*)dependabot(.*)

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Run pre-commit for the commit-msg hook
+pre-commit run --hook-stage commit-msg --commit-msg-filename "$1"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+---
+default_stages: [ pre-commit ]
+
+repos:
+  - repo: https://github.com/jorisroovers/gitlint
+    rev: v0.19.1
+    hooks:
+      - id: gitlint
+        name: Git Lint
+        stages: [commit-msg]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# DI One Login Home
+
+## Guide
+
+### Pre-Commit check with Husky and GitLint
+Pre-commit checks is configured via GitLint to ensure commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
+To set up pre-commit checks, you need to install the pre-commit hooks and run the post-install script. This will ensure that your commit messages are checked against the rules defined in the `.pre-commit-config.yaml` file.
+To install the pre-commit hooks, run the following command:
+```shell
+$ npm install
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,12 +4,16 @@
   "requires": true,
   "packages": {
     "": {
+      "hasInstallScript": true,
       "dependencies": {
         "@govuk-prototype-kit/common-templates": "2.0.1",
         "govuk-frontend": "5.10.0",
         "govuk-one-login-service-header": "github:govuk-one-login/service-header",
         "govuk-prototype-kit": "13.16.2",
         "hmrc-frontend": "6.65.0"
+      },
+      "devDependencies": {
+        "husky": "^9.1.7"
       }
     },
     "node_modules/@govuk-prototype-kit/common-templates": {
@@ -1692,6 +1696,21 @@
       "version": "10.17.60",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
       "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -4793,6 +4812,12 @@
           "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
         }
       }
+    },
+    "husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "scripts": {
     "dev": "govuk-prototype-kit dev",
     "serve": "govuk-prototype-kit serve",
-    "start": "govuk-prototype-kit start"
+    "start": "govuk-prototype-kit start",
+    "postinstall": "husky"
   },
   "dependencies": {
     "@govuk-prototype-kit/common-templates": "2.0.1",
@@ -10,5 +11,8 @@
     "govuk-one-login-service-header": "github:govuk-one-login/service-header",
     "govuk-prototype-kit": "13.16.2",
     "hmrc-frontend": "6.65.0"
+  },
+  "devDependencies": {
+    "husky": "^9.1.7"
   }
 }


### PR DESCRIPTION
## Proposed changes

Standardise commit messages through pre-commit checks

### What changed
Add GitLint precommit library to ensure commit messages adhere to a set of standards, for example must have the ticket number - This gives the benefit of linking the github commit against the correct ticket in JIRA.

### Why did it change

- So that our commit messages are standardised
- With the existence of JIRA ticket number in commit messages, commits are liked to a specific JIRA ticket.

### Issue tracking
https://govukverify.atlassian.net/browse/OLH-2647

## Testing

- A colleague checks out this branch
- Follow the readme
- Attempts to commit with a non standardised message, should fail
- Attempt to commit with a standardised message, should pass

## Checklists
- [ ] Did not commit any not-required changes to the `src/infra/**/samconfig.toml`
- [x] Tested changes and included test evidence in the PR, if appropriate
