### PR TITLE
BAU: change dependabot schedule to biweekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,10 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: daily
+      interval: "cron"
+      cronjob: "0 3 1,15 * *"
       time: "03:00"
+      timezone: "Europe/London"
     cooldown:
       default-days: 7
     target-branch: main


### PR DESCRIPTION
Changes dependabot version update schedule from daily to biweekly (1st and 15th of each month).

This reduces PR noise while still keeping dependencies reasonably current. Security vulnerability alerts are unaffected — those will continue to be raised immediately regardless of this schedule.